### PR TITLE
Change column width to fix text falling to the next line

### DIFF
--- a/get-started/api.md
+++ b/get-started/api.md
@@ -1297,6 +1297,12 @@ A list of paginated Batch objects.
 
 The status of a Batch object can be one of the following:
 
+<style>
+table th:first-child {
+    width: 130px;
+}
+</style>
+
 | Status        | Description                                                             |
 |---------------|-------------------------------------------------------------------------|
 | `Validating`  | The input file is being validated.                                      |


### PR DESCRIPTION
Added a small snippet to widen the column width to prevent characters from falling to the next line.