### PR TITLE
Embed getting-started notebook into the docs

### DIFF
--- a/tutorials/klusterai-api/.pages
+++ b/tutorials/klusterai-api/.pages
@@ -1,4 +1,5 @@
 title: kluster.ai API
 hide: false
 nav:
+ - 'Getting Started': getting-started.ipynb
  - 'Multiple Batch Predictions': multiple-tasks-batch-api.ipynb

--- a/tutorials/klusterai-api/getting-started.ipynb
+++ b/tutorials/klusterai-api/getting-started.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f08513ae-21ba-4e77-9bad-2bc5c51f4d68",
+   "metadata": {},
+   "source": [
+    "# Getting Started with the kluster.ai Batch API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9d0174-a10b-4eb0-a811-dd11deba2f6d",
+   "metadata": {},
+   "source": [
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/getting-started.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d2c4269-59e8-456c-8939-35cf0bdda3c9",
+   "metadata": {},
+   "source": [
+    "Welcome to the Batch API Getting Started Notebook!\n",
+    "\n",
+    "<a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> is a high-performance compute platform designed to make large-scale AI workloads accessible, efficient, and affordable. Our Batch API enables a variety of use cases, including summarization, classification, translation, and more, all without the need to manage infrastructure.\n",
+    "\n",
+    "This notebook is designed to help you get started quickly with the <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> Batch API. It walks you through the essential code snippets from the <a href=\"https://docs.kluster.ai/get-started/api/\" target=\"_blank\">Getting Started documentation</a>, all in one place.\n",
+    "\n",
+    "By running this notebook, you’ll:\n",
+    "- Learn how to use the API.\n",
+    "- Submit a simple batch job for LLM inference.\n",
+    "- Understand how to handle and interpret the API’s responses.\n",
+    "\n",
+    "Each section corresponds to a step in the Getting Started guide, so you can follow along seamlessly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9adbe5d",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b43e4c18",
+   "metadata": {},
+   "source": [
+    "This step ensures that the openai Python library is installed or updated to the required version. This library will serve as the client for interacting with the kluster.ai Batch API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28f85f2a-4ffc-4180-b439-906493833a2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install \"openai>=1.0.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b089f9c-e3fd-4411-966e-fabe5d392e4c",
+   "metadata": {},
+   "source": [
+    "## Creating Batch Jobs as JSONL Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "291a9b10",
+   "metadata": {},
+   "source": [
+    "This step defines a batch of requests for the API to process. Each request includes a unique identifier (`custom_id`), the HTTP method (`POST`), the chat completions endpoint (`/v1/chat/completions`) and a body field that contains the request you want to send to the chat completions endpoint toghether with the `model` to be used and the conversational context (\"messages\"). These tasks are saved as a JSON Lines (`.jsonl`) file for efficient handling of multiple requests in a single upload.\n",
+    "\n",
+    "You'll have to enter your personal kluster.ai API key (make sure it has no blank spaces). Remember to create a key in <a href=\"https://platform.kluster.ai/apikeys\" target=\"_blank\">platform.kluster.ai</a>, if you don't have one yet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ebb21d1-df49-4784-a5de-f1a7367dd481",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "import json\n",
+    "client = OpenAI(\n",
+    "    base_url=\"https://api.kluster.ai/v1\",  \n",
+    "    api_key=\"INSERT_API_KEY\", # Replace with your actual API key\n",
+    ")\n",
+    "\n",
+    "tasks = [{\n",
+    "        \"custom_id\": \"request-1\",\n",
+    "        \"method\": \"POST\",\n",
+    "        \"url\": \"/v1/chat/completions\",\n",
+    "        \"body\": {\n",
+    "            \"model\": \"klusterai/Meta-Llama-3.1-8B-Instruct-Turbo\",\n",
+    "            \"messages\": [\n",
+    "                {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "                {\"role\": \"user\", \"content\": \"What is the capital of Argentina?\"},\n",
+    "            ],\n",
+    "            \"max_tokens\": 1000,\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"custom_id\": \"request-2\",\n",
+    "        \"method\": \"POST\",\n",
+    "        \"url\": \"/v1/chat/completions\",\n",
+    "        \"body\": {\n",
+    "            \"model\": \"klusterai/Meta-Llama-3.1-70B-Instruct-Turbo\",\n",
+    "            \"messages\": [\n",
+    "                {\"role\": \"system\", \"content\": \"You are a maths tutor.\"},\n",
+    "                {\"role\": \"user\", \"content\": \"Explain the Pythagorean theorem.\"},\n",
+    "            ],\n",
+    "            \"max_tokens\": 1000,\n",
+    "        },\n",
+    "    }\n",
+    "    # Additional tasks can be added here\n",
+    "]\n",
+    "\n",
+    "# Save tasks to a JSONL file (newline-delimited JSON)\n",
+    "file_name = \"mybatchtest.jsonl\"\n",
+    "with open(file_name, \"w\") as file:\n",
+    "    for task in tasks:\n",
+    "        file.write(json.dumps(task) + \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ceb6a52-2cef-45ae-8e3e-fe31491c4ca2",
+   "metadata": {},
+   "source": [
+    "## Uploading Batch job Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1518be55",
+   "metadata": {},
+   "source": [
+    "This step uploads the input JSONL file to kluster.ai via the API. Once the file is uploaded, the API assigns a unique file ID. This ID is essential for subsequent steps, as it allows you to specify which file the batch job should use for processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a7dd436-f8e2-4a93-ba22-fddbdc0b4aed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_input_file = client.files.create(\n",
+    "    file=open(file_name, \"rb\"),\n",
+    "    purpose=\"batch\"\n",
+    ")\n",
+    "\n",
+    "batch_input_file.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d1d0e43-f222-4024-ba6a-8564d2aca71f",
+   "metadata": {},
+   "source": [
+    "## Submit your Batch Job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30e53475",
+   "metadata": {},
+   "source": [
+    "This step starts your batch job by providing the uploaded file ID and setting the endpoint and completion window, initiating the batch process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4537dd26-2058-415f-8b0c-cab75604e455",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_request = client.batches.create(\n",
+    "    input_file_id=batch_input_file.id,\n",
+    "    endpoint=\"/v1/chat/completions\",\n",
+    "    completion_window=\"24h\",\n",
+    ")\n",
+    "\n",
+    "batch_request.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feca0141-731a-4751-8418-77dff33adadf",
+   "metadata": {},
+   "source": [
+    "## Monitor Job Progress"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b01ed74c",
+   "metadata": {},
+   "source": [
+    "In this step, the batch job status is checked repeatedly to track its progress. You’ll see updates on the overall status and the number of completed tasks until the job is finished, failed, or cancelled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c15527d-5bf0-48c8-b31c-53d19934e0ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "# Poll the batch status until it's complete\n",
+    "while True:\n",
+    "    batch_status = client.batches.retrieve(batch_request.id)\n",
+    "    print(\"Batch status: {}\".format(batch_status.status))\n",
+    "    print(\n",
+    "        f\"Completed tasks: {batch_status.request_counts.completed} / {batch_status.request_counts.total}\"\n",
+    "    )\n",
+    "\n",
+    "    if batch_status.status.lower() in [\"completed\", \"failed\", \"cancelled\"]:\n",
+    "        break\n",
+    "\n",
+    "    time.sleep(10)  # Wait for 10 seconds before checking again\n",
+    "\n",
+    "batch_status.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bfa97a0-03d6-45d7-95f8-947198a0ef8e",
+   "metadata": {},
+   "source": [
+    "## Retrieve Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c734ea16",
+   "metadata": {},
+   "source": [
+    "In this step, the results of the batch job are retrieved if it completed successfully. The output is downloaded and saved to a local file for you to review. If the job failed, the status will indicate the issue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66542b1d-85aa-4350-9551-bd40db7f56ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check if the batch completed successfully\n",
+    "if batch_status.status.lower() == \"completed\":\n",
+    "    # Retrieve the results\n",
+    "    result_file_id = batch_status.output_file_id\n",
+    "    results = client.files.content(result_file_id).content\n",
+    "\n",
+    "    # Save results to a file\n",
+    "    result_file_name = \"batch_results.jsonl\"\n",
+    "    with open(result_file_name, \"wb\") as file:\n",
+    "        file.write(results)\n",
+    "    print(f\"Results saved to {result_file_name}\")\n",
+    "else:\n",
+    "    print(f\"Batch failed with status: {batch_status.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73016a7-24af-47e2-aa35-a71f39300a88",
+   "metadata": {},
+   "source": [
+    "## List all Batch Jobs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac081d6e",
+   "metadata": {},
+   "source": [
+    "This step lists the most recent batch jobs, providing an overview of their statuses and details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1063f7f1-1cc3-4501-8293-9e1962a70e81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.batches.list(limit=2).to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4f9f1db-c226-4529-850b-f07fb4f6d695",
+   "metadata": {},
+   "source": [
+    "## Cancelling a Batch Job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a61d05d",
+   "metadata": {},
+   "source": [
+    "To cancel a batch job that is currently in progress, invoke the batch cancel endpoint by providing the batch ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38ba4b1a-f527-4adc-a20d-d94afacf52fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.batches.cancel(batch_request.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8926edc8-b270-4f69-94f6-7745b5606080",
+   "metadata": {},
+   "source": [
+    "## List supported models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149225c5",
+   "metadata": {},
+   "source": [
+    "Find the right model for your job by first checking the list models endpoint. Choose from our range of models, optimized for different performance needs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5be116c1-677d-4f3a-be86-c4b76f1284dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.models.list().to_dict()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Description

I embedded the [getting started notebook](https://github.com/kluster-ai/klusterai-cookbook/blob/main/examples/getting-started.ipynb) into the docs under Tutorial section. 
To observe the results clone `joaquin/getting-started-notebook` and run `mkdcos serve`.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
