### PR TITLE
Change max file limit from 6 GB to 200 MB

### DIFF
--- a/get-started/api.md
+++ b/get-started/api.md
@@ -602,7 +602,7 @@ Next, to submit a Batch job, you invoke the `batches` endpoint using the `input_
 
 The ID of an uploaded file that contains requests for the new Batch.
 
-Your input file must be formatted as a [JSONL file](https://jsonlines.org/){target=\_blank}, and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests and currently a maximum of 200MB per file.
+Your input file must be formatted as a [JSONL file](https://jsonlines.org/){target=\_blank}, and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests and currently a maximum of 200 MB per file.
 
 ---
 


### PR DESCRIPTION
### Description

The docs should state that the max file limit is 200 MB (previously this was set to 6 GB)

### Checklist

- [x ] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [n/a ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
