### PR TITLE
update kluster.ai styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains documentation for [kluster.ai](https://kluster.ai), the
 
 ## About This Site
 
-The content in this repository is displayed on the **kluster.ai** documentation site generated using [MkDocs](https://www.mkdocs.org). The theme used is [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
+The content in this repository is displayed on the kluster.ai documentation site generated using [MkDocs](https://www.mkdocs.org). The theme used is [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 
 ## Contributing
 

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1050,7 +1050,7 @@ The object type, which is always `batch`.
 
 `endpoint` ++"string"++
 
-The **kluster.ai** API endpoint used by the Batch.
+The kluster.ai API endpoint used by the Batch.
 
 ---
 
@@ -1230,7 +1230,7 @@ Set of 16 key-value pairs that can be attached to an object. This is useful for 
 
 Upload a [JSON Lines](https://jsonlines.org/){target=\_blank} file to the `files` endpoint.
 
-You can also view all your uploaded files in the [**Files** tab](https://platform.kluster.ai/files){target=\_blank} of the **kluster.ai** platform.
+You can also view all your uploaded files in the [**Files** tab](https://platform.kluster.ai/files){target=\_blank} of the kluster.ai platform.
 
 <div class="grid" markdown>
 <div markdown>
@@ -1651,7 +1651,7 @@ The intended purpose of the file. Currently, only `batch` is supported.
 
 Lists the currently available models.
 
-You can use this endpoint to retrieve a list of all available models for the **kluster.ai** API. Currently supported models include:
+You can use this endpoint to retrieve a list of all available models for the kluster.ai API. Currently supported models include:
 
 - `klusterai/Meta-Llama-3.1-8B-Instruct-Turbo`
 - `klusterai/Meta-Llama-3.1-405B-Instruct-Turbo`

--- a/get-started/get-api-key.md
+++ b/get-started/get-api-key.md
@@ -5,13 +5,13 @@ description: Follow step-by-step instructions to generate and manage API keys, e
 
 # Generate your kluster.ai API key
 
-The API key is a unique identifier that authenticates requests associated with your account. You must have at least one API key to access **kluster.ai**'s services.
+The API key is a unique identifier that authenticates requests associated with your account. You must have at least one API key to access [kluster.ai](https://www.kluster.ai/){target=\_blank}'s services.
 
-This guide will help you obtain an API key, the first step to leveraging **kluster.ai**'s powerful and cost-effective AI capabilities.
+This guide will help you obtain an API key, the first step to leveraging kluster.ai's powerful and cost-effective AI capabilities.
 
 ## Create an account
 
-If you haven't already created an account with **kluster.ai**, visit the [registration page](https://platform.kluster.ai/signup){target=\_blank} and take the following steps:
+If you haven't already created an account with kluster.ai, visit the [registration page](https://platform.kluster.ai/signup){target=\_blank} and take the following steps:
 
 1. Enter your full name
 2. Provide a valid email address
@@ -50,7 +50,7 @@ After you've signed up or logged into the platform through the [login page](http
 
 ## Managing your API keys
 
-The **API Key Management** section allows you to efficiently manage your **kluster.ai** API keys. You can create, view, and delete API keys by navigating to the [**API Keys**](https://platform.kluster.ai/apikeys){target=\_blank} section. Your API keys will be listed in the **API Key Management** section.
+The **API Key Management** section allows you to efficiently manage your kluster.ai API keys. You can create, view, and delete API keys by navigating to the [**API Keys**](https://platform.kluster.ai/apikeys){target=\_blank} section. Your API keys will be listed in the **API Key Management** section.
 
 To delete an API key, take the following steps:
 
@@ -65,4 +65,4 @@ To delete an API key, take the following steps:
 
 ## Next steps
 
-Now that you have your API key, you can start integrating **kluster.ai**'s LLMs into your applications. Refer to our [Getting Started](/get-started/start-api/){target=\_blank} guide for detailed instructions on using the API.
+Now that you have your API key, you can start integrating kluster.ai's LLMs into your applications. Refer to our [Getting Started](/get-started/start-api/){target=\_blank} guide for detailed instructions on using the API.

--- a/get-started/start-api.md
+++ b/get-started/start-api.md
@@ -5,7 +5,7 @@ description: The kluster.ai API getting started guide provides examples and inst
 
 # Start using the kluster.ai API
 
-The **kluster.ai** API provides a straightforward way to work with Large Language Models (LLMs) at scale. It is compatible with OpenAI's API and SDKs, making it easy to integrate into your existing workflows with minimal code changes.
+The [kluster.ai](https://www.kluster.ai/){target=\_blank} API provides a straightforward way to work with Large Language Models (LLMs) at scale. It is compatible with OpenAI's API and SDKs, making it easy to integrate into your existing workflows with minimal code changes.
 
 This guide provides copy-and-paste examples for both Python and curl (although all OpenAI's SDKs are supported) and detailed explanations to help you get started quickly.
 
@@ -19,16 +19,16 @@ pip install "openai>=1.0.0"
 
 ## Get your API key
 
-Navigate to the **kluster.ai** developer console [**API Keys**](https://platform.kluster.ai/apikeys){target=\_blank} section and create a new key from there. You'll need this for all API requests.
+Navigate to the kluster.ai developer console [**API Keys**](https://platform.kluster.ai/apikeys){target=\_blank} section and create a new key from there. You'll need this for all API requests.
 
 For step-by-step instructions, refer to the [Get an API key](/get-started/get-api-key){target=\_blank} guide.
 
 ## Batch job workflow overview
 
-Working with Batch jobs in the **kluster.ai** API involves the following steps:
+Working with Batch jobs in the kluster.ai API involves the following steps:
 
 1. **Create Batch job file** - prepare a JSON Lines file containing one or more chat completion requests to be executed in the batch
-2. **Upload Batch job file** - upload the file to **kluster.ai** to receive a unique file ID
+2. **Upload Batch job file** - upload the file to kluster.ai to receive a unique file ID
 3. **Start the Batch job** - initiate a new Batch job using the file ID
 4. **Monitor job progress** - track the status of your Batch job to ensure successful completion
 5. **Retrieve results** - once the job finishes, access and process the results as needed
@@ -148,7 +148,7 @@ Upload your [JSON Lines](https://jsonlines.org/){target=\_blank} file to the `fi
 The response will contain an `id` field; save this value as you'll need it in the next step, where it's referred to as `input_file_id`.
 
 !!! note
-    You can also view all your uploaded files in the [**Files** tab](https://platform.kluster.ai/files){target=\_blank} of the **kluster.ai** platform.
+    You can also view all your uploaded files in the [**Files** tab](https://platform.kluster.ai/files){target=\_blank} of the kluster.ai platform.
 
 === "Python"
 
@@ -247,7 +247,7 @@ To monitor your Batch job's progress, make periodic requests to the `batches` en
 To see a complete list of the supported statuses, refer to the [Retrieve a batch](/api-reference/reference/#retrieve-a-batch){target=\_blank} API reference page.
 
 !!! note
-    You can also monitor jobs in the [**Batch** tab](https://platform.kluster.ai/batch) of the **kluster.ai** platform UI.
+    You can also monitor jobs in the [**Batch** tab](https://platform.kluster.ai/batch) of the kluster.ai platform UI.
 
 === "Python"
 
@@ -459,7 +459,7 @@ To cancel a Batch job currently in progress, send a request to the `cancel` endp
 
 ## Summary
 
-Congratulations! You now have all the tools needed to work with the **kluster.ai** Batch API. In this guide, you've learned how to:
+Congratulations! You now have all the tools needed to work with the kluster.ai Batch API. In this guide, you've learned how to:
 
 - Prepare and submit Batch jobs with structured request inputs
 - Track your jobs' progress in real-time
@@ -468,4 +468,4 @@ Congratulations! You now have all the tools needed to work with the **kluster.ai
 - Cancel jobs when needed
 - View supported models
 
-The **kluster.ai** Batch API is designed to efficiently and reliably handle your large-scale LLM workloads. Do you have questions or suggestions? The [support](mailto:support@kluster.ai){target=\_blank} team would love to hear from you.
+The kluster.ai Batch API is designed to efficiently and reliably handle your large-scale LLM workloads. Do you have questions or suggestions? The [support](mailto:support@kluster.ai){target=\_blank} team would love to hear from you.


### PR DESCRIPTION
### Description

This PR makes the following updates to resolve inconsistencies when referring to kluster.ai:

- First instance of [kluster.ai](http://kluster.ai/) on a page should always be a link
- All subsequent instances can be normal text - no link, no bold
- Do not capitalize kluster.ai under any circumstances

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
