### PR TITLE
use the api template

### DIFF
--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -3,6 +3,7 @@ title: API Reference
 description: Explore the kluster.ai API reference to get a comprehensive overview on the available endpoints, request and response formats, and integration examples.
 hide:
  - navigation
+template: api.html
 ---
 
 # API reference


### PR DESCRIPTION
### Description

This implements the API template (created in this PR https://github.com/papermoonio/kluster-mkdocs/pull/21), so that the TOC shows up on the left side

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
