### PR TITLE
Add Embeddings to API Reference

### DIFF
--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1578,7 +1578,7 @@ Creates an embedding vector representing the input text. Machine learning models
 
 `input` ++"string or array"++ <span class="required" markdown>++"required"++</span>
 
-Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), cannot be an empty string, and any array must be 2048 dimensions or less.
+Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or an array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), it cannot be an empty string, and any array must be 2048 dimensions or less.
 
 ---
 

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1588,23 +1588,13 @@ ID of the model to use.
 
 ---
 
-`dimensions` ++"integer"++
-
-The number of dimensions the resulting output embeddings should have.
-
----
-
 `encoding_format` ++"string"++
 
 The format to return the embeddings in. Can be either `float` or `base64`. Defaults to `float`.
 
 ---
 
-`user` ++"string"++
-
-A unique identifier representing your end-user.
-
----
+Please note, the embeddings endpoint doesn’t support the dimensions parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying dimensions will trigger a `400 Bad Request`.
 
 **Returns**
 

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1704,7 +1704,7 @@ The index of the embedding in the list of embeddings.
 
 `object` ++"string"++
 
-The object type, which is always embedding.
+The object type, which is always `"embedding"`.
 
 </div>
 <div markdown>

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1569,7 +1569,7 @@ The intended purpose of the file. Currently, only `batch` is supported.
 
 `POST https://api.kluster.ai/v1/embeddings`
 
-Creates an embedding vector representing the input text. These vector representations can be easily consumed by machine learning models and algorithms to understand semantic relationships between pieces of text.
+Creates an embedding vector representing the input text. Machine learning models and algorithms can easily consume these vector representations to understand semantic relationships between pieces of text.
 
 <div class="grid" markdown>
 <div markdown>

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1563,6 +1563,170 @@ The intended purpose of the file. Currently, only `batch` is supported.
 
 ---
 
+## Embeddings
+
+### Create embeddings
+
+`POST https://api.kluster.ai/v1/embeddings`
+
+Creates an embedding vector representing the input text. These vector representations can be easily consumed by machine learning models and algorithms to understand semantic relationships between pieces of text.
+
+<div class="grid" markdown>
+<div markdown>
+
+**Request**
+
+`input` ++"string or array"++ <span class="required" markdown>++"required"++</span>
+
+Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less.
+
+---
+
+`model` ++"string"++ <span class="required" markdown>++"required"++</span>
+
+ID of the model to use. You can use the List models API to see all of your available models, or see our Model overview for descriptions of them.
+
+---
+
+`dimensions` ++"integer"++
+
+The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+
+---
+
+`encoding_format` ++"string"++
+
+The format to return the embeddings in. Can be either `float` or `base64`. Defaults to `float`.
+
+---
+
+`user` ++"string"++
+
+A unique identifier representing your end-user, which can help kluster.ai to monitor and detect abuse.
+
+---
+
+**Returns**
+
+A list of [embedding objects](#the-embedding-object).
+
+</div>
+<div markdown>
+
+=== "Python"
+
+    ```python title="Example request"
+    from openai import OpenAI
+
+    # Configure OpenAI client
+    client = OpenAI(
+        base_url="https://api.kluster.ai/v1",
+        api_key="INSERT_API_KEY",  # Replace with your actual API key
+    )
+
+    response = client.embeddings.create(
+        model="BAAI/bge-m3",
+        input="The food was delicious and the waiter...",
+        encoding_format="float"
+    )
+
+    print(response)
+    ```
+
+=== "curl"
+
+    ```bash title="Example request"
+    curl -s https://api.kluster.ai/v1/embeddings \
+        -H "Authorization: Bearer $API_KEY" \
+        -H "Content-Type: application/json" \
+        -d '{
+        "input": "The food was delicious and the waiter...",
+        "model": "BAAI/bge-m3",
+        "encoding_format": "float"
+        }'
+    ```
+
+```Json title="Response"
+{
+  "object": "list",
+  "created": 1744935248,
+  "model": "BAAI/bge-m3",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [
+        0.00885772705078125,
+        -0.0010204315185546875,
+        -0.045135498046875,
+        0.00478363037109375,
+        -0.02642822265625,
+        /* ... truncated for brevity ... */
+        -0.0168304443359375,
+        0.0229339599609375,
+        0.007648468017578125,
+        -0.03875732421875,
+        0.05487060546875
+      ]
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 13
+  }
+}
+```
+
+</div>
+</div>
+
+---
+
+### The embedding object
+
+Represents an embedding vector returned by the embeddings endpoint.
+
+<div class="grid" markdown>
+<div markdown>
+
+**Properties**
+
+`embedding` ++"array"++
+
+The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the embedding guide.
+
+---
+
+`index` ++"integer"++
+
+The index of the embedding in the list of embeddings.
+
+---
+
+`object` ++"string"++
+
+The object type, which is always "embedding".
+
+</div>
+<div markdown>
+
+```Json title="The embedding object"
+{
+  "object": "embedding",
+  "embedding": [
+    0.0023064255,
+    -0.009327292,
+    ... (1536 floats total for ada-002)
+    -0.0028842222
+  ],
+  "index": 0
+}
+```
+
+</div>
+</div>
+
+---
+
 ## Models
 
 ### List supported models

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1578,19 +1578,19 @@ Creates an embedding vector representing the input text. These vector representa
 
 `input` ++"string or array"++ <span class="required" markdown>++"required"++</span>
 
-Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less.
+Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), cannot be an empty string, and any array must be 2048 dimensions or less.
 
 ---
 
 `model` ++"string"++ <span class="required" markdown>++"required"++</span>
 
-ID of the model to use. You can use the List models API to see all of your available models, or see our Model overview for descriptions of them.
+ID of the model to use.
 
 ---
 
 `dimensions` ++"integer"++
 
-The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+The number of dimensions the resulting output embeddings should have.
 
 ---
 
@@ -1602,13 +1602,13 @@ The format to return the embeddings in. Can be either `float` or `base64`. Defau
 
 `user` ++"string"++
 
-A unique identifier representing your end-user, which can help kluster.ai to monitor and detect abuse.
+A unique identifier representing your end-user.
 
 ---
 
 **Returns**
 
-A list of [embedding objects](#the-embedding-object).
+A list of [embedding objects](#embedding-object).
 
 </div>
 <div markdown>
@@ -1681,7 +1681,7 @@ A list of [embedding objects](#the-embedding-object).
 
 ---
 
-### The embedding object
+### Embedding object
 
 Represents an embedding vector returned by the embeddings endpoint.
 
@@ -1692,7 +1692,7 @@ Represents an embedding vector returned by the embeddings endpoint.
 
 `embedding` ++"array"++
 
-The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the embedding guide.
+The embedding vector, which is a list of floats.
 
 ---
 
@@ -1704,7 +1704,7 @@ The index of the embedding in the list of embeddings.
 
 `object` ++"string"++
 
-The object type, which is always "embedding".
+The object type, which is always embedding.
 
 </div>
 <div markdown>
@@ -1713,10 +1713,17 @@ The object type, which is always "embedding".
 {
   "object": "embedding",
   "embedding": [
-    0.0023064255,
-    -0.009327292,
-    ... (1536 floats total for ada-002)
-    -0.0028842222
+    0.00885772705078125,
+    -0.0010204315185546875,
+    -0.045135498046875,
+    0.00478363037109375,
+    -0.02642822265625,
+    /* ... truncated for brevity ... */
+    -0.0168304443359375,
+    0.0229339599609375,
+    0.007648468017578125,
+    -0.03875732421875,
+    0.05487060546875
   ],
   "index": 0
 }

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1594,7 +1594,9 @@ The format to return the embeddings in. Can be either `float` or `base64`. Defau
 
 ---
 
-Please note, the embeddings endpoint doesn’t support the dimensions parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying dimensions will trigger a `400 Bad Request`.
+`dimensions` <span class="not-supported" markdown>++"not supported"++</span>
+
+Please note, the embeddings endpoint doesn’t support the `dimensions` parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying `dimensions` will trigger a `400 Bad Request`.
 
 **Returns**
 

--- a/api-reference/reference.md
+++ b/api-reference/reference.md
@@ -1608,7 +1608,7 @@ A unique identifier representing your end-user.
 
 **Returns**
 
-A list of [embedding objects](#embedding-object).
+A list of [Embedding objects](#embedding-object).
 
 </div>
 <div markdown>

--- a/llms.txt
+++ b/llms.txt
@@ -1661,6 +1661,177 @@ The intended purpose of the file. Currently, only `batch` is supported.
 
 ---
 
+## Embeddings
+
+### Create embeddings
+
+`POST https://api.kluster.ai/v1/embeddings`
+
+Creates an embedding vector representing the input text. These vector representations can be easily consumed by machine learning models and algorithms to understand semantic relationships between pieces of text.
+
+<div class="grid" markdown>
+<div markdown>
+
+**Request**
+
+`input` ++"string or array"++ <span class="required" markdown>++"required"++</span>
+
+Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), cannot be an empty string, and any array must be 2048 dimensions or less.
+
+---
+
+`model` ++"string"++ <span class="required" markdown>++"required"++</span>
+
+ID of the model to use.
+
+---
+
+`dimensions` ++"integer"++
+
+The number of dimensions the resulting output embeddings should have.
+
+---
+
+`encoding_format` ++"string"++
+
+The format to return the embeddings in. Can be either `float` or `base64`. Defaults to `float`.
+
+---
+
+`user` ++"string"++
+
+A unique identifier representing your end-user.
+
+---
+
+**Returns**
+
+A list of [embedding objects](#embedding-object).
+
+</div>
+<div markdown>
+
+=== "Python"
+
+    ```python title="Example request"
+    from openai import OpenAI
+
+    # Configure OpenAI client
+    client = OpenAI(
+        base_url="https://api.kluster.ai/v1",
+        api_key="INSERT_API_KEY",  # Replace with your actual API key
+    )
+
+    response = client.embeddings.create(
+        model="BAAI/bge-m3",
+        input="The food was delicious and the waiter...",
+        encoding_format="float"
+    )
+
+    print(response)
+    ```
+
+=== "curl"
+
+    ```bash title="Example request"
+    curl -s https://api.kluster.ai/v1/embeddings \
+        -H "Authorization: Bearer $API_KEY" \
+        -H "Content-Type: application/json" \
+        -d '{
+        "input": "The food was delicious and the waiter...",
+        "model": "BAAI/bge-m3",
+        "encoding_format": "float"
+        }'
+    ```
+
+```Json title="Response"
+{
+  "object": "list",
+  "created": 1744935248,
+  "model": "BAAI/bge-m3",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [
+        0.00885772705078125,
+        -0.0010204315185546875,
+        -0.045135498046875,
+        0.00478363037109375,
+        -0.02642822265625,
+        /* ... truncated for brevity ... */
+        -0.0168304443359375,
+        0.0229339599609375,
+        0.007648468017578125,
+        -0.03875732421875,
+        0.05487060546875
+      ]
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 13
+  }
+}
+```
+
+</div>
+</div>
+
+---
+
+### Embedding object
+
+Represents an embedding vector returned by the embeddings endpoint.
+
+<div class="grid" markdown>
+<div markdown>
+
+**Properties**
+
+`embedding` ++"array"++
+
+The embedding vector, which is a list of floats.
+
+---
+
+`index` ++"integer"++
+
+The index of the embedding in the list of embeddings.
+
+---
+
+`object` ++"string"++
+
+The object type, which is always embedding.
+
+</div>
+<div markdown>
+
+```Json title="The embedding object"
+{
+  "object": "embedding",
+  "embedding": [
+    0.00885772705078125,
+    -0.0010204315185546875,
+    -0.045135498046875,
+    0.00478363037109375,
+    -0.02642822265625,
+    /* ... truncated for brevity ... */
+    -0.0168304443359375,
+    0.0229339599609375,
+    0.007648468017578125,
+    -0.03875732421875,
+    0.05487060546875
+  ],
+  "index": 0
+}
+```
+
+</div>
+</div>
+
+---
+
 ## Models
 
 ### List supported models

--- a/llms.txt
+++ b/llms.txt
@@ -1692,7 +1692,9 @@ The format to return the embeddings in. Can be either `float` or `base64`. Defau
 
 ---
 
-Please note, the embeddings endpoint doesn’t support the dimensions parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying dimensions will trigger a `400 Bad Request`.
+`dimensions` <span class="not-supported" markdown>++"not supported"++</span>
+
+Please note, the embeddings endpoint doesn’t support the `dimensions` parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying `dimensions` will trigger a `400 Bad Request`.
 
 **Returns**
 

--- a/llms.txt
+++ b/llms.txt
@@ -1667,7 +1667,7 @@ The intended purpose of the file. Currently, only `batch` is supported.
 
 `POST https://api.kluster.ai/v1/embeddings`
 
-Creates an embedding vector representing the input text. These vector representations can be easily consumed by machine learning models and algorithms to understand semantic relationships between pieces of text.
+Creates an embedding vector representing the input text. Machine learning models and algorithms can easily consume these vector representations to understand semantic relationships between pieces of text.
 
 <div class="grid" markdown>
 <div markdown>
@@ -1676,7 +1676,7 @@ Creates an embedding vector representing the input text. These vector representa
 
 `input` ++"string or array"++ <span class="required" markdown>++"required"++</span>
 
-Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), cannot be an empty string, and any array must be 2048 dimensions or less.
+Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or an array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `BAAI/bge-m3`), it cannot be an empty string, and any array must be 2048 dimensions or less.
 
 ---
 
@@ -1686,27 +1686,17 @@ ID of the model to use.
 
 ---
 
-`dimensions` ++"integer"++
-
-The number of dimensions the resulting output embeddings should have.
-
----
-
 `encoding_format` ++"string"++
 
 The format to return the embeddings in. Can be either `float` or `base64`. Defaults to `float`.
 
 ---
 
-`user` ++"string"++
-
-A unique identifier representing your end-user.
-
----
+Please note, the embeddings endpoint doesn’t support the dimensions parameter. Models such as `BAAI/bge‑m3` always return a fixed 1024‑dimensional vector. Supplying dimensions will trigger a `400 Bad Request`.
 
 **Returns**
 
-A list of [embedding objects](#embedding-object).
+A list of [Embedding objects](#embedding-object).
 
 </div>
 <div markdown>
@@ -1802,7 +1792,7 @@ The index of the embedding in the list of embeddings.
 
 `object` ++"string"++
 
-The object type, which is always embedding.
+The object type, which is always `"embedding"`.
 
 </div>
 <div markdown>


### PR DESCRIPTION
### Description

Adds Embeddings to the upload API. 

The Embeddings API is scheduled to be released to production on Tuesday. 

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
