### PR TITLE
API Matic portal preview

### DIFF
--- a/api-reference/.pages
+++ b/api-reference/.pages
@@ -1,4 +1,5 @@
 title: API reference
 hide: false
 nav:
- - 'Reference': reference.md
+ # - 'Reference': reference.md
+ - 'API reference': api-portal.md

--- a/api-reference/api-portal.md
+++ b/api-reference/api-portal.md
@@ -1,0 +1,8 @@
+---
+title: API reference
+description: The kluster.ai API reference includes endpoints, available methods, required parameters, and response format information for kluster.ai's OpenAI-compatible API.
+hide: nav
+template: portal.html
+---
+
+# kluster.ai API reference


### PR DESCRIPTION
### Description

This PR adds the portal template to the front matter for the API Reference page and updates the nav to use the portal page while leaving the legacy reference page intact. 

### Checklist

- [ x] **Required** - I have added a label to this PR 🏷️
- [ n/a] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo --> I did not do anything with redirects yet.
