### PR TITLE
Add a URL config to the link checker workflow

### DIFF
--- a/.github/workflows/pr-link-checker.yml
+++ b/.github/workflows/pr-link-checker.yml
@@ -11,5 +11,6 @@ jobs:
       docs_repo: kluster-ai/docs
       mkdocs_repo_name: kluster-mkdocs
       docs_repo_name: kluster-docs
+      url: https://docs.kluster.ai
     secrets:
       GH_TOKEN: ${{ secrets.GH_PR_404_CHECKER }}


### PR DESCRIPTION
### Description

This pull request includes a small addition to the `.github/workflows/pr-link-checker.yml` file. It adds a `url` parameter to the `jobs:` section, specifying the documentation URL for kluster.

This is used to convert markdown file paths to URLs, which can then be excluded from the link checker workflow.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️


Goes with: https://github.com/papermoonio/workflows/pull/2/files