### PR TITLE
Tutorial Link fix

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -19546,7 +19546,7 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/text-classification
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",
@@ -19661,7 +19661,7 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/text-classification
     "\n",
     "This example uses `klusterai/Meta-Llama-3.1-8B-Instruct-Turbo`, but feel free to comment it and uncomment any other model you want to try out.\n",
     "\n",
-    "Please refer to the <a href=\"/get-started/models/\" target=\"_blank\">Supported models</a> section for a list of the models we support.\n"
+    "Please refer to the <a href=\"https://docs.kluster.ai/get-started/models/\" target=\"_blank\">Supported models</a> section for a list of the models we support.\n"
    ]
   },
   {

--- a/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
+++ b/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
@@ -27,7 +27,7 @@
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",
@@ -142,7 +142,7 @@
     "\n",
     "This example uses `klusterai/Meta-Llama-3.1-8B-Instruct-Turbo`, but feel free to comment it and uncomment any other model you want to try out.\n",
     "\n",
-    "Please refer to the <a href=\"/get-started/models/\" target=\"_blank\">Supported models</a> section for a list of the models we support.\n"
+    "Please refer to the <a href=\"https://docs.kluster.ai/get-started/models/\" target=\"_blank\">Supported models</a> section for a list of the models we support.\n"
    ]
   },
   {


### PR DESCRIPTION
### Description

I checked all the tutorials for broken links, I only found one. 

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
