### PR TITLE
Tutorial Link Fixes

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -17564,7 +17564,7 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/reliability-check.i
     "id": "b17a77d9"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/tutorials/kluster-api/reliability-check.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/reliability-check.ipynb)"
    ]
   },
   {
@@ -19549,7 +19549,7 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/text-classification
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-curator/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",

--- a/llms.txt
+++ b/llms.txt
@@ -19549,7 +19549,7 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/text-classification
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-curator/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",

--- a/tutorials/klusterai-api/reliability-check.ipynb
+++ b/tutorials/klusterai-api/reliability-check.ipynb
@@ -17,7 +17,7 @@
     "id": "b17a77d9"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/tutorials/kluster-api/reliability-check.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/reliability-check.ipynb)"
    ]
   },
   {

--- a/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
+++ b/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
@@ -27,7 +27,7 @@
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-curator/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",

--- a/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
+++ b/tutorials/klusterai-api/text-classification/text-classification-curator.ipynb
@@ -27,7 +27,7 @@
     "id": "6d1d06ea-79c1-4f28-b312-0e5aabe18ff3"
    },
    "source": [
-    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-curator/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
+    "This notebook goes through the same example as in our previous <a href=\"https://docs.kluster.ai/tutorials/klusterai-api/text-classification/text-classification-openai-api/\" target=\"_blank\">Text classification notebook</a>, but this time, we'll be using Bespoke Curator instead of the OpenAI Python library\n",
     "\n",
     "To recap, the notebook uses <a href=\"https://kluster.ai/\" target=\"_blank\">kluster.ai</a> batch API to classify a data set based on a predefined set of categories.\n",
     "\n",


### PR DESCRIPTION
### Description

Replaces: https://github.com/kluster-ai/docs/pull/150
This pull request updates links in documentation and notebooks to ensure consistency and correctness. The changes primarily involve fixing URLs and paths to improve navigation and usability.

### Documentation Updates:
* Updated the Colab link in `llms.txt` and `tutorials/klusterai-api/reliability-check.ipynb` to point to the correct path (`examples/reliability-check.ipynb` instead of `tutorials/kluster-api/reliability-check.ipynb`). [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L17567-R17567) [[2]](diffhunk://#diff-3f4aaeb4e4c4445d94ea68b570c0acd5d6a7da1e45e1e7dfb5bb7a2b89449e32L20-R20)
* Corrected the hyperlink in `llms.txt` and `tutorials/klusterai-api/text-classification/text-classification-curator.ipynb` to use the full URL (`https://docs.kluster.ai/...`) instead of a relative path (`/tutorials/...`). [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L19552-R19552) [[2]](diffhunk://#diff-2fa7004dfc7b9988e8819bd0ea7127027b129d16c306ed37e0bac98f094103b7L30-R30)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
