### PR TITLE
Add Rag collab link

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -16755,6 +16755,14 @@ Doc-Content: https://docs.kluster.ai/tutorials/klusterai-api/rag.ipynb/
   },
   {
    "cell_type": "markdown",
+   "id": "b17a77d9",
+   "metadata": {},
+   "source": [
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/rag.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8566fe2a",
    "metadata": {},
    "source": [

--- a/tutorials/klusterai-api/rag.ipynb
+++ b/tutorials/klusterai-api/rag.ipynb
@@ -10,6 +10,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b17a77d9",
+   "metadata": {},
+   "source": [
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/rag.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8566fe2a",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This pull request adds a Colab badge to the tutorial for retrieval-augmented generation (RAG), allowing users to open the example notebook directly in Google Colab for interactive use.

Enhancements to tutorial accessibility:

* [`llms.txt`](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R16756-R16763): Added a Colab badge link to the RAG tutorial documentation, enabling users to quickly access the example notebook in Google Colab.
* [`tutorials/klusterai-api/rag.ipynb`](diffhunk://#diff-1e7a09bf495d6f49ef6a1a154828bf155a3976a5a148094a003e80784c76c13bR11-R18): Included a Colab badge in the RAG tutorial notebook for seamless access to the interactive example.### Description

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
