### PR TITLE
patch output path for llms.txt

### DIFF
--- a/scripts/llms_config.json
+++ b/scripts/llms_config.json
@@ -8,6 +8,7 @@
     "branch": "main",
     "docs_path": "."
   },
+  "output_path": "llms.txt",
   "source_repos": [
     {
       "name": "kluster.ai cookbook",


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `scripts/llms_config.json` file, specifying a new output path for generated files.

* Configuration update:
  * Added the `output_path` property set to `llms.txt` to define where output should be saved.
  * 
 ### Description

Please explain the changes this PR addresses here.

### Checklist

- [ x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
