### PR TITLE
update script

### DIFF
--- a/.github/workflows/trigger-n8n-workflow.yml
+++ b/.github/workflows/trigger-n8n-workflow.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   gather-and-send:
     # Manual dispatch is allowed, but we verify the actor has write access before continuing.
+    # Pull request runs still skip forks to avoid leaking secrets.
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request != null && github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: n8n-sending
@@ -232,7 +233,7 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
-          chunk_size = 8000
+          chunk_size = 8000 
           diff_contents = Path("diff.b64").read_text()
           for start in range(0, len(diff_contents), chunk_size):
               chunk = diff_contents[start:start + chunk_size]
@@ -661,7 +662,7 @@ jobs:
     needs:
       - gather-and-send
       - receive-validate-and-comment
-    if: ${{ always() && (needs.gather-and-send.result == 'failure' || needs.receive-validate-and-comment.result == 'failure') && needs.gather-and-send.outputs.send_executed != 'true' }}
+    if: ${{ always() && ((needs.gather-and-send.result == 'failure' && (needs.gather-and-send.outputs.send_executed != 'true' || needs.gather-and-send.outputs.send_error == 'true')) || needs.receive-validate-and-comment.result == 'failure') }}
     env:
       GATHER_RESULT: ${{ needs.gather-and-send.result }}
       RECEIVE_RESULT: ${{ needs.receive-validate-and-comment.result }}


### PR DESCRIPTION
### Description

Adding new updates  to N8n script: 
1. omits artifact information
2. Character Activation Threshold
3. Addition of an error notification, so no silent failures
4. Resolved argument to long error

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the n8n GitHub Actions workflow with diff-size gating, output-based payload handoff (no artifacts), stronger masking/error handling, and a failure notification job.
> 
> - **CI Workflow (`.github/workflows/trigger-n8n-workflow.yml`)**:
>   - **Run context & outputs**: Capture PR/run metadata and expose new outputs (`should_send`, `diff_char_count`, `pr_number`, `repository`, `run_url`, `response_payload`, `cancelled`, `send_executed`, `send_error`).
>   - **Diff gating**: Add `MIN_DIFF_CHAR_THRESHOLD` and a threshold evaluation/short-circuit to skip small diffs.
>   - **Security/robustness**:
>     - Chunked masking for `diff.b64`.
>     - Build payload with Python, include `RUN_TOKEN`, and set step outputs for `cancelled`/`error` without hard-failing.
>     - Treat oversized payloads and non-2xx/invalid responses as soft errors via outputs.
>   - **Handoff changes**: Remove artifact upload/download; pass n8n response via job outputs; update receive job condition to require `should_send`; restore payload from output; cleanup temp files.
>   - **Failure alerts**: Add `notify-on-failure` job to post error webhooks with run context when gather/send or receive steps fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70ba7f6e10e8176906e1cee1bf9876fde2b774a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->