### PR TITLE
Fix Tools Page 404

### DIFF
--- a/code-reviews/tools.md
+++ b/code-reviews/tools.md
@@ -130,6 +130,6 @@ Code review assigns priority levels to detected issues, helping you focus on the
 
 ## Next steps
 
-- **[Configure settings](/code-reviews/configuration/)**: Customize review behavior for your needs.
+- **[Configure settings](/code-reviews/configuration/options/)**: Customize review behavior for your needs.
 - **[Set up integrations](/code-reviews/quickstart/)**: Configure IDE integrations to use these tools.
 - **[Get started](/code-reviews/quickstart/)**: Follow the quickstart guide for immediate setup.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1017,7 +1017,7 @@ Code review assigns priority levels to detected issues, helping you focus on the
 
 ## Next steps
 
-- **[Configure settings](/code-reviews/configuration/)**: Customize review behavior for your needs.
+- **[Configure settings](/code-reviews/configuration/options/)**: Customize review behavior for your needs.
 - **[Set up integrations](/code-reviews/quickstart/)**: Configure IDE integrations to use these tools.
 - **[Get started](/code-reviews/quickstart/)**: Follow the quickstart guide for immediate setup.
 --- END CONTENT ---

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ This file is intended for AI models and developers. Use it to:
 - Explore optional resources (see Optional)
 
 ## Metadata
-- Documentation pages: 6
+- Documentation pages: 7
 - Source repositories: 2
 - Optional resources: 0
 
@@ -20,6 +20,7 @@ This section lists documentation pages. Each entry includes the page title, a di
 - [tools](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/tools.md): No description available.
 - [Options](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/configuration/options.md): Configure kluster.ai Code Reviews settings including sensitivity levels, bug types, and enabled tools for AI-generated code reviews.
 - [rules](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/configuration/rules.md): No description available.
+- [How to use activation codes](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/faq/activation-codes.md): This guide explains how to redeem activation codes and apply them to your kluster account
 - [cursor-firebase-nextjs](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/examples/cursor-firebase-nextjs.md): No description available.
 - [vscode-admin-endpoint](https://raw.githubusercontent.com/kluster-ai/docs/refs/heads/main/code-reviews/examples/vscode-admin-endpoint.md): No description available.
 


### PR DESCRIPTION
### Description

Fixes a tools page 404. 
This pull request updates documentation links and metadata to reflect the addition of a new guide and the reorganization of configuration settings. The most important changes are grouped below.

Documentation updates:

* Updated the "Configure settings" link in both `code-reviews/tools.md` and `llms-full.txt` to point to `/code-reviews/configuration/options/` instead of `/code-reviews/configuration/`, ensuring users are directed to the correct configuration options page. [[1]](diffhunk://#diff-3b172ae1d978b9e28a795e999b1f0190a9ad18a90fea8d2d026128958fcfa264L133-R133) [[2]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L1020-R1020)
* Added a new documentation entry for "How to use activation codes" in `llms.txt`, providing guidance on redeeming and applying activation codes for kluster accounts.

Metadata updates:

* Increased the documentation pages count from 6 to 7 in `llms.txt` to reflect the addition of the new guide.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix broken configuration link in tools docs and update docs index to include activation codes page (metadata count to 7).
> 
> - **Docs**:
>   - **Links**: Update "Configure settings" in `code-reviews/tools.md` and `llms-full.txt` to point to `/code-reviews/configuration/options/`.
>   - **Index/Metadata (`llms.txt`)**:
>     - Increase documentation pages count from `6` to `7`.
>     - Add new entry: `How to use activation codes` with raw URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e5e8b2a5306b5771116cb13d5a345fbb36562e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->