### PR TITLE
Add npm cache error troubleshooting and replace MCP status image with…

### DIFF
--- a/.snippets/code/code-reviews/troubleshooting/mcp-connected.md
+++ b/.snippets/code/code-reviews/troubleshooting/mcp-connected.md
@@ -1,0 +1,30 @@
+<div data-termynal>
+  <span data-ty>╭─── Claude Code v2.1.63 ────────────────────────────╮</span>
+  <span data-ty>│                                                    │</span>
+  <span data-ty>│               Welcome back kluster.ai!             │</span>
+  <span data-ty>│                                                    │</span>
+  <span data-ty>│                     ▐▛███▜▌                        │</span>
+  <span data-ty>│                    ▝▜█████▛▘                       │</span>
+  <span data-ty>│                      ▘▘ ▝▝                         │</span>
+  <span data-ty>│                                                    │</span>
+  <span data-ty>│  Opus 4.6 · Claude Max · kluster's Organization    │</span>
+  <span data-ty>│                      /workspace                    │</span>
+  <span data-ty>╰────────────────────────────────────────────────────╯</span>
+  <span data-ty></span>
+  <span data-ty="input" data-ty-prompt="❯ "> /mcp</span>
+  <span data-ty></span>
+  <span data-ty>  Kluster-verify MCP Server</span>
+  <span data-ty></span>
+  <span data-ty>  Status: ✔ connected</span>
+  <span data-ty>  Command: npx</span>
+  <span data-ty>  Args: -y @klusterai/kluster-verify-code-mcp@latest</span>
+  <span data-ty>  Config location: ~/.claude.json</span>
+  <span data-ty>  Capabilities: tools</span>
+  <span data-ty>  Tools: 3 tools</span>
+  <span data-ty></span>
+  <span data-ty>  › 1. View tools</span>
+  <span data-ty>    2. Reconnect</span>
+  <span data-ty>    3. Disable</span>
+  <span data-ty></span>
+  <span data-ty>  escape to go back</span>
+</div>

--- a/code-reviews/troubleshooting.md
+++ b/code-reviews/troubleshooting.md
@@ -38,13 +38,44 @@ This error occurs when npx caches a broken or incomplete package download. Clear
 
 After clearing the cache, restart your IDE or CLI tool.
 
+### Auto-update fails with npm cache error
+
+<div data-termynal>
+  <span data-ty>[info] Starting new stdio process with command: npx -y @klusterai/kluster-verify-node-mcp@latest</span>
+  <span data-ty style="color: #ff6b6b;">npm error ENOTEMPTY: directory not empty, rename '/Users/.../.npm/_npx/.../node_modules/@klusterai/...' -> '...'</span>
+</div>
+
+The npm client sometimes fails to update cached packages when temporary directories or lock files from a previous run are left behind. This typically produces `ENOTEMPTY`, `EEXIST`, or `EPERM` errors. When the auto-update fails, the MCP server cannot start because the package download is interrupted.
+
+Run the following command to clear the npm cache:
+
+```bash
+npm cache clean --force
+```
+
+After clearing the cache, restart your IDE or CLI tool. The next MCP invocation downloads a fresh copy of the package.
+
+If the error persists, remove the npx cache directory manually (same step as for the [Cannot find module](#cannot-find-module-constants) error, but here it serves as a fallback after `npm cache clean`):
+
+=== "macOS / Linux"
+
+    ```bash
+    rm -rf ~/.npm/_npx
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Remove-Item -Recurse -Force "$env:LOCALAPPDATA\npm-cache\_npx"
+    ```
+
 ### Claude Code MCP server shows "failed"
 
 In Claude Code, the MCP server may show `✘ failed` on the first connection attempt. This happens because Claude Code has a 10-second timeout for MCP startup, and the initial npx download can take longer when there's no cache.
 
-Simply restart Claude Code. The second attempt will use the cached package and connect successfully. Run `/mcp` to verify the MCP server is connected:
+Restart Claude Code. The second attempt will use the cached package and connect successfully. Run `/mcp` to verify the MCP server is connected:
 
-![Claude Code MCP server status showing connected](/images/code-reviews/get-started/installation/troubleshooting/troubleshooting-1.webp)
+--8<-- 'code/code-reviews/troubleshooting/mcp-connected.md'
 
 ### Debugging CLI installation issues
 


### PR DESCRIPTION

Add a new troubleshooting section for ENOTEMPTY/EEXIST/EPERM npm cache errors that block npx auto-updates and prevent the MCP server from starting. Includes npm cache clean --force as the primary fix, with manual cache removal as a fallback. Also replaces the static MCP status screenshot with a termynal block using NBSP-safe snippet for minify plugin compatibility, and fixes "Simply" hedging word in adjacent section.

### Description

This pull request improves the troubleshooting documentation for MCP server connectivity and auto-update issues in Claude Code. It adds a new interactive terminal snippet to illustrate a successful MCP connection and provides detailed instructions for resolving npm cache errors that can prevent auto-updates.

Key documentation improvements:

**Troubleshooting npm cache errors:**
- Added a new section explaining how to resolve `ENOTEMPTY`, `EEXIST`, or `EPERM` errors during MCP auto-update, including step-by-step instructions to clear the npm cache and manually remove the npx cache directory on macOS, Linux, and Windows.

**Visual feedback for successful MCP connection:**
- Introduced a new interactive terminal snippet (`mcp-connected.md`) that visually demonstrates a successful MCP server connection and available options, replacing the previous static screenshot for better clarity. [[1]](diffhunk://#diff-01b9d34ec3487a8ff9572470470529a9db567fd98d51fc35956e903332bd8a81R1-R30) [[2]](diffhunk://#diff-1caa5441dd05083a7ad02251b75733ce5b46748f973624114b2059bae1313226R41-R78)


### Checklist

- [x] **Required** - I have added a label to this PR 🏷️