### PR TITLE
Clarify Azure DevOps does not support any custom rules

### DIFF
--- a/code-reviews/configuration/rules.md
+++ b/code-reviews/configuration/rules.md
@@ -28,7 +28,7 @@ To accommodate different workflows, Code Reviews supports two types of rules:
     ![Connect to GitHub](/images/code-reviews/configuration/rules/rules-01.webp)
 
     !!! note
-        Rule extraction and project-specific learned rules are currently available for GitHub repositories only. Azure DevOps, GitLab, and Bitbucket repositories do not support automatic rule extraction at this time.
+        Rule extraction and project-specific learned rules are currently available for GitHub repositories only. GitLab and Bitbucket do not support automatic rule extraction at this time. Azure DevOps does not support custom rules of any kind, including manual rules.
 
 3. Click **Add review rule** to create custom rules.
 


### PR DESCRIPTION
The previous note grouped Azure DevOps with GitLab and Bitbucket as lacking only automatic rule extraction. This was misleading since Azure DevOps does not support custom rules at all, including manual rules, unlike GitLab and Bitbucket, which do.

### Description

This pull request updates the documentation for the Code Reviews rule configuration to clarify support for custom and automatic rule extraction across different repository providers.

Documentation clarification:

* Updated the note in `rules.md` to specify that GitLab and Bitbucket do not support automatic rule extraction, and that Azure DevOps does not support custom rules of any kind, including manual rules.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
