### PR TITLE
Add PR Reviews nav, permissions warnings, uninstall commands, and rules

### DIFF
--- a/.nav.yml
+++ b/.nav.yml
@@ -3,7 +3,7 @@ nav:
  - ':custom-sparkles: Review Modes': code-reviews/review-modes.md
  - ':custom-rocket: Get Started': code-reviews/get-started
  - ':custom-monitor: IDE Reviews': code-reviews/ide-reviews
-# - ':custom-git: PR Reviews': code-reviews/pr-reviews
+ - ':custom-git: PR Reviews': code-reviews/pr-reviews
  - ':custom-folder: Repo Reviews': code-reviews/repo-reviews
  - ':custom-terminal: CLI': code-reviews/cli
  - ':custom-database: External Knowledge': code-reviews/external-knowledge

--- a/.snippets/text/code-reviews/pr-reviews-enterprise.md
+++ b/.snippets/text/code-reviews/pr-reviews-enterprise.md
@@ -1,2 +1,2 @@
 !!! note "Enterprise plan"
-    PR Reviews is available exclusively on the Enterprise plan. To enable PR Reviews for your organization, contact the kluster.ai team at [info@kluster.ai](mailto:info@kluster.ai){target=\_blank}.
+    PR Reviews is available exclusively on the Enterprise plan. To enable PR Reviews for your organization, contact the kluster.ai team at [sales@kluster.ai](mailto:sales@kluster.ai){target=\_blank}.

--- a/.snippets/text/code-reviews/pr-reviews-enterprise.md
+++ b/.snippets/text/code-reviews/pr-reviews-enterprise.md
@@ -1,0 +1,2 @@
+!!! note "Enterprise plan"
+    PR Reviews is available exclusively on the Enterprise plan. To enable PR Reviews for your organization, contact the kluster.ai team at [info@kluster.ai](mailto:info@kluster.ai){target=\_blank}.

--- a/code-reviews/configuration/rules.md
+++ b/code-reviews/configuration/rules.md
@@ -30,7 +30,7 @@ To accommodate different workflows, Code Reviews supports two types of rules:
     !!! note
         Rule extraction and project-specific learned rules are currently available for GitHub repositories only. GitLab and Bitbucket do not support automatic rule extraction at this time. Azure DevOps repositories in Code Reviews do not support custom rules of any kind, including manual and learned rules.
 
-3. For supported providers, click **Add review rule** to create custom rules.
+3. For GitHub, GitLab, and Bitbucket providers, click **Add review rule** to create custom rules.
 
     ![Add review rule button](/images/code-reviews/configuration/rules/rules-02.webp)
 

--- a/code-reviews/configuration/rules.md
+++ b/code-reviews/configuration/rules.md
@@ -28,9 +28,9 @@ To accommodate different workflows, Code Reviews supports two types of rules:
     ![Connect to GitHub](/images/code-reviews/configuration/rules/rules-01.webp)
 
     !!! note
-        Rule extraction and project-specific learned rules are currently available for GitHub repositories only. GitLab and Bitbucket do not support automatic rule extraction at this time. Azure DevOps does not support custom rules of any kind, including manual rules.
+        Rule extraction and project-specific learned rules are currently available for GitHub repositories only. GitLab and Bitbucket do not support automatic rule extraction at this time. Azure DevOps repositories in Code Reviews do not support custom rules of any kind, including manual and learned rules.
 
-3. Click **Add review rule** to create custom rules.
+3. For supported providers, click **Add review rule** to create custom rules.
 
     ![Add review rule button](/images/code-reviews/configuration/rules/rules-02.webp)
 

--- a/code-reviews/get-started/installation.md
+++ b/code-reviews/get-started/installation.md
@@ -57,6 +57,10 @@ Before getting started, ensure you have:
 
     ![Active MCP Tools in VS Code](/images/code-reviews/get-started/installation/vscode/vscode-integration-6.webp)
 
+    **Uninstall**
+
+    To remove kluster.ai from VS Code, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
+
 === "Cursor"
 
     1. Click the **Add to Cursor** button below.
@@ -78,6 +82,10 @@ Before getting started, ensure you have:
         --8<-- 'text/code-reviews/code-tools.md'
 
         ![Active MCP Tools in Cursor](/images/code-reviews/get-started/installation/cursor/cursor-integration-2.webp)
+
+    **Uninstall**
+
+    To remove kluster.ai from Cursor, open **Settings** > **Extensions**, find **Kluster Code Reviews**, and click **Uninstall**.
 
 === "JetBrains"
 
@@ -120,6 +128,10 @@ Before getting started, ensure you have:
 
         ![Active kluster.ai plugin in JetBrains](/images/code-reviews/get-started/installation/jetbrains/jetbrains-integration-5.webp)
 
+    **Uninstall**
+
+    To remove kluster.ai from your JetBrains IDE, go to **Settings** > **Plugins**, find **kluster.ai**, and click **Uninstall**. Restart the IDE when prompted.
+
 === "Windsurf"
 
     1. Click the **Add to Windsurf** button below.
@@ -161,6 +173,10 @@ Before getting started, ensure you have:
 
         ![Active MCP Tools in Windsurf](/images/code-reviews/get-started/installation/windsurf/windsurf-integration-7.webp)
 
+    **Uninstall**
+
+    To remove kluster.ai from Windsurf, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
+
 === "Antigravity"
 
     1. Click the **Add to Antigravity** button below.
@@ -197,6 +213,10 @@ Before getting started, ensure you have:
     2. Verify that **Kluster-Verify-Code** appears with all tools enabled.
 
         ![Active MCP Tools in Antigravity](/images/code-reviews/get-started/installation/antigravity/antigravity-integration-6.webp)
+
+    **Uninstall**
+
+    To remove kluster.ai from Antigravity, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
 
 ### Terminal tools
 
@@ -237,6 +257,14 @@ Before getting started, ensure you have:
 
     ![Claude Code Installation Demo](/images/code-reviews/get-started/installation/claudecode/claude.gif)
 
+    **Uninstall**
+
+    To remove kluster.ai from Claude Code, run:
+
+    ```bash
+    npx -y @klusterai/ide-installer@latest uninstall claude
+    ```
+
 === "Codex CLI"
 
     **Terminal installation**
@@ -270,6 +298,14 @@ Before getting started, ensure you have:
 
     ![Codex CLI Installation Demo](/images/code-reviews/get-started/installation/codex-cli/codex-cli.gif)
 
+    **Uninstall**
+
+    To remove kluster.ai from Codex CLI, run:
+
+    ```bash
+    npx -y @klusterai/ide-installer@latest uninstall codex
+    ```
+
 === "CLI (Standalone)"
 
     kluster-cli is a standalone command-line tool that works without an IDE or AI assistant. Install it directly on macOS, Linux, or Windows.
@@ -295,6 +331,10 @@ Before getting started, ensure you have:
     For shell completions, updates, and more, see the full [CLI installation guide](/code-reviews/cli/installation/).
 
     [:octicons-arrow-right-24: CLI quickstart](/code-reviews/cli/quickstart/)
+
+    **Uninstall**
+
+    To remove the kluster CLI, see the [CLI installation guide](/code-reviews/cli/installation/) for platform-specific uninstall instructions.
 
 ## Next steps
 

--- a/code-reviews/pr-reviews/azure-devops.md
+++ b/code-reviews/pr-reviews/azure-devops.md
@@ -24,11 +24,11 @@ Once connected, the bot reviews every new pull request and every new commit push
 Before getting started, ensure you have:
 
 - A [kluster.ai](https://platform.kluster.ai/signup){target=\_blank} account.
-- An Azure DevOps account with **Project Administrator** or **Project Collection Administrator** permissions in the projects you want to review.
+- An Azure DevOps account that is a member of **Project Collection Administrators** in your organization.
 - A personal access token with the required scopes. See [Create a personal access token](#create-a-personal-access-token) for instructions.
 
 !!! warning "Verify account permissions"
-    The account that generates the personal access token must have **Project Administrator** or **Project Collection Administrator** permissions. Having the correct token scopes is not enough — the account itself needs administrator-level permissions to install webhooks. If the account has insufficient permissions, webhook installation will fail silently and pull request reviews will not appear. To fix this, add the user to **Project Collection Administrators** in **Organization Settings** > **Security** > **Permissions**. After updating permissions, click **Re-install** on the PR Reviews page in the kluster.ai platform to complete the setup.
+    The account that generates the personal access token must be a member of **Project Collection Administrators**. Having the correct token scopes is not enough — the account itself needs this role to install webhooks. If the account has insufficient permissions, webhook installation will fail silently and pull request reviews will not appear. To fix this, navigate to **Organization Settings** > **Security** > **Permissions**, find the user, and add them to **Project Collection Administrators**. After updating permissions, click **Re-install** on the PR Reviews page in the kluster.ai platform to complete the setup.
 
 ## Admin consent
 

--- a/code-reviews/pr-reviews/azure-devops.md
+++ b/code-reviews/pr-reviews/azure-devops.md
@@ -24,8 +24,11 @@ Once connected, the bot reviews every new pull request and every new commit push
 Before getting started, ensure you have:
 
 - A [kluster.ai](https://platform.kluster.ai/signup){target=\_blank} account.
-- An Azure DevOps account with at least **Basic** access to the projects you want to review.
+- An Azure DevOps account with **Project Administrator** or **Project Collection Administrator** permissions in the projects you want to review.
 - A personal access token with the required scopes. See [Create a personal access token](#create-a-personal-access-token) for instructions.
+
+!!! warning "Verify account permissions"
+    The account that generates the personal access token must have **Project Administrator** or **Project Collection Administrator** permissions. Having the correct token scopes is not enough — the account itself needs administrator-level permissions to install webhooks. If the account has insufficient permissions, webhook installation will fail silently and pull request reviews will not appear. To fix this, add the user to **Project Collection Administrators** in **Organization Settings** > **Security** > **Permissions**. After updating permissions, click **Re-install** on the PR Reviews page in the kluster.ai platform to complete the setup.
 
 ## Admin consent
 

--- a/code-reviews/pr-reviews/azure-devops.md
+++ b/code-reviews/pr-reviews/azure-devops.md
@@ -12,6 +12,8 @@ Before connecting, an administrator in your Azure DevOps organization must compl
 
 Once connected, the bot reviews every new pull request and every new commit pushed to an open pull request. No additional configuration is needed.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 --8<-- 'text/code-reviews/pr-reviews-tip.md'
 
 !!! warning "Custom rules not supported"

--- a/code-reviews/pr-reviews/bitbucket.md
+++ b/code-reviews/pr-reviews/bitbucket.md
@@ -20,6 +20,9 @@ Before getting started, ensure you have:
 - A Bitbucket account with **developer** access to the repositories you want to review.
 - A Bitbucket API token. See [Create an API token](#create-an-api-token) for instructions.
 
+!!! warning "Verify account permissions"
+    The account that generates the API token must have at least **developer** access to the target repositories. Having the correct token scopes is not enough — the account itself needs developer-level permissions. If the account has insufficient access, webhook installation will fail and pull request reviews will not appear. After fixing the account's permissions, click **Re-install** on the PR Reviews page in the kluster.ai platform to complete the setup.
+
 ## Create an API token
 
 The kluster.ai bot requires a Bitbucket API token to access your repositories and post review comments. Tokens are created through your Atlassian account settings.

--- a/code-reviews/pr-reviews/bitbucket.md
+++ b/code-reviews/pr-reviews/bitbucket.md
@@ -10,6 +10,8 @@ Connect the [kluster.ai](https://www.kluster.ai/){target=\_blank} bot to your Bi
 
 Once connected, the bot reviews every new pull request and every new commit pushed to an open pull request. No additional configuration is needed.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 --8<-- 'text/code-reviews/pr-reviews-tip.md'
 
 ## Prerequisites

--- a/code-reviews/pr-reviews/github.md
+++ b/code-reviews/pr-reviews/github.md
@@ -10,6 +10,8 @@ Connect the [kluster.ai](https://www.kluster.ai/){target=\_blank} bot to your Gi
 
 Once connected, the bot reviews every new PR and every new commit pushed to an open PR. No additional configuration is needed.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 --8<-- 'text/code-reviews/pr-reviews-tip.md'
 
 ## Prerequisites

--- a/code-reviews/pr-reviews/gitlab.md
+++ b/code-reviews/pr-reviews/gitlab.md
@@ -10,6 +10,8 @@ Connect the [kluster.ai](https://www.kluster.ai/){target=\_blank} bot to your Gi
 
 Once connected, the bot reviews every new merge request and every new commit pushed to an open merge request. No additional configuration is needed.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 --8<-- 'text/code-reviews/pr-reviews-tip.md'
 
 ## Prerequisites

--- a/code-reviews/pr-reviews/gitlab.md
+++ b/code-reviews/pr-reviews/gitlab.md
@@ -20,6 +20,9 @@ Before getting started, ensure you have:
 - A GitLab account with at least **Developer** access to the projects you want to review.
 - A GitLab access token with the `api` scope. See [Create an access token](#create-an-access-token) for instructions.
 
+!!! warning "Verify account permissions"
+    The account that generates the access token must have at least **Developer** role in the target project or group. Having the correct token scopes (such as `api`) is not enough — the account itself needs Developer-level permissions. If the account only has Guest access, webhook installation will fail silently and PR reviews will not appear. After fixing the account's role, click **Re-install** on the PR Reviews page in the kluster.ai platform to complete the setup.
+
 ## Create an access token
 
 The kluster.ai bot requires a GitLab access token with the `api` scope to read merge requests and post review comments.

--- a/code-reviews/pr-reviews/quickstart.md
+++ b/code-reviews/pr-reviews/quickstart.md
@@ -13,6 +13,8 @@ The bot acts as a last line of defense. It catches issues that were missed durin
 !!! tip "Best used as a safety net"
     PR Reviews is most effective when combined with earlier review stages. Install the [kluster.ai extension](/code-reviews/get-started/installation/) in your IDE or set up [CLI hooks](/code-reviews/cli/git-hooks/) to catch issues while you code. The PR bot then confirms nothing was missed.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 ## How it works
 
 Once installed, the kluster.ai bot triggers automatically in two situations:

--- a/code-reviews/pr-reviews/quickstart.md
+++ b/code-reviews/pr-reviews/quickstart.md
@@ -10,10 +10,10 @@ PR Reviews connects a [kluster.ai](https://www.kluster.ai/){target=\_blank} bot 
 
 The bot acts as a last line of defense. It catches issues that were missed during development, whether you used IDE reviews, CLI checks, or no kluster tooling at all. Every PR gets an ultra-deep analysis that examines your changes for bugs, security vulnerabilities, and quality problems before they reach your main branch.
 
+--8<-- 'text/code-reviews/pr-reviews-enterprise.md'
+
 !!! tip "Best used as a safety net"
     PR Reviews is most effective when combined with earlier review stages. Install the [kluster.ai extension](/code-reviews/get-started/installation/) in your IDE or set up [CLI hooks](/code-reviews/cli/git-hooks/) to catch issues while you code. The PR bot then confirms nothing was missed.
-
---8<-- 'text/code-reviews/pr-reviews-enterprise.md'
 
 ## How it works
 

--- a/code-reviews/troubleshooting.md
+++ b/code-reviews/troubleshooting.md
@@ -142,6 +142,23 @@ Or split the review by reviewing individual files:
 kluster review file src/large-file.go
 ```
 
+## PR Reviews
+
+### Azure DevOps PR reviews not appearing
+
+After connecting Azure DevOps, pull request reviews may not appear if the account used to generate the personal access token lacks the required permissions to install webhooks.
+
+To fix this:
+
+1. Navigate to **Azure DevOps** > **Organization Settings** > **Security** > **Permissions**.
+2. Find the user account that generated the personal access token.
+3. Open the **Member of** tab and add the user to **Project Collection Administrators**.
+4. Return to the [PR Reviews](https://platform.kluster.ai/pr-bot-installation){target=\_blank} page in the kluster.ai platform and click **Re-install** on the Azure DevOps integration.
+
+After re-installing, each new pull request should receive review comments from kluster.
+
+For more details on the required permissions, see the [Azure DevOps setup guide](/code-reviews/pr-reviews/azure-devops/).
+
 ## Need help?
 
 If your issue isn't listed here or you need additional support, join our [Discord community](https://discord.com/invite/klusterai){target=\_blank}.

--- a/code-reviews/troubleshooting.md
+++ b/code-reviews/troubleshooting.md
@@ -155,7 +155,7 @@ To fix this:
 3. Open the **Member of** tab and add the user to **Project Collection Administrators**.
 4. Return to the [PR Reviews](https://platform.kluster.ai/pr-bot-installation){target=\_blank} page in the kluster.ai platform and click **Re-install** on the Azure DevOps integration.
 
-After re-installing, each new pull request should receive review comments from kluster.
+After re-installing, each new pull request should receive review comments from the kluster.ai bot.
 
 For more details on the required permissions, see the [Azure DevOps setup guide](/code-reviews/pr-reviews/azure-devops/).
 


### PR DESCRIPTION
- Uncomment PR Reviews section in sidebar navigation
- Add prominent permissions warning admonition to GitLab and Bitbucket PR Reviews pages (account needs Developer access, not just token scopes)
- Add uninstall sections to all IDE and terminal tool tabs in the installation page
- Clarify Azure DevOps custom rules note and add "For supported providers" qualifier to step 3

### Description

This pull request updates the documentation for code reviews with several improvements focused on clarity, usability, and completeness. The main changes include adding explicit uninstall instructions for all supported editors and tools, clarifying rule support for Azure DevOps, updating navigation, and providing important warnings about required permissions when setting up PR reviews for Bitbucket and GitLab.

**Uninstallation instructions for all supported editors and tools:**

- Added clear uninstall steps for kluster.ai in the installation guide for VS Code, Cursor, JetBrains IDEs, Windsurf, Antigravity, Claude Code, Codex CLI, and the standalone CLI. This provides users with straightforward instructions to remove the integration from any environment. [[1]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R60-R63) [[2]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R86-R89) [[3]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R131-R134) [[4]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R176-R179) [[5]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R217-R220) [[6]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R260-R267) [[7]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R301-R308) [[8]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R335-R338)

**Configuration and permissions clarifications:**

- Updated the rules configuration documentation to clarify that Azure DevOps repositories in Code Reviews do not support custom rules of any kind, including both manual and learned rules. Also, clarified that adding review rules is only available for supported providers.
- Added prominent warnings to the Bitbucket and GitLab PR review setup guides, explaining that the account generating the API/access token must have at least Developer access to the target repositories/projects. This helps prevent silent failures during webhook installation and ensures reviews function correctly. [[1]](diffhunk://#diff-bebdea903a26d714f0ece695adf7014659cc9d34920679a8407223ace0fcce4bR23-R25) [[2]](diffhunk://#diff-32fd4d49e0b12de2db89df8706ae813cb89e2d9583899750d4ba5e46dd06ef03R23-R25)

**Navigation improvements:**

- Fixed the navigation entry for PR Reviews in the sidebar by uncommenting the relevant line in `.nav.yml`, making it visible and accessible.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
