### PR TITLE
add new flag for faq

### DIFF
--- a/code-reviews/faq.md
+++ b/code-reviews/faq.md
@@ -2,6 +2,7 @@
 title: Code Reviews Frequently Asked Questions
 description: Find answers to common questions about kluster.ai Code Review, covering setup, supported IDEs, review modes, security, and troubleshooting topics.
 categories: Troubleshooting
+faq: categorized
 ---
 
 # Frequently Asked Questions


### PR DESCRIPTION
### Description
This PR adds a new flag for the FAQ section 
Needs to be merged with this one:  https://github.com/papermoonio/kluster-mkdocs/pull/172
### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [x] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
