### PR TITLE
Fix/antigravity ide scheme and manual login

### DIFF
--- a/.snippets/text/install-button-antigravity.md
+++ b/.snippets/text/install-button-antigravity.md
@@ -1,1 +1,1 @@
-[:octicons-arrow-right-24: Add to Antigravity](antigravity:extension/klusterai.kluster-verify-code){target=\_blank .md-button .md-button--primary}
+[:octicons-arrow-right-24: Add to Antigravity](antigravity-ide:extension/klusterai.kluster-verify-code){target=\_blank .md-button .md-button--primary}

--- a/.snippets/text/install-manual-login.md
+++ b/.snippets/text/install-manual-login.md
@@ -1,0 +1,7 @@
+If the browser sign-in flow is unavailable or fails, you can log in with an API key instead:
+
+1. Open the [kluster.ai platform](https://platform.kluster.ai){target=\_blank} and sign in.
+2. Click your user menu in the top-right corner.
+3. Select **Manual IDE login**.
+4. Copy the displayed key.
+5. Paste the key into the API key field in your IDE's kluster.ai panel.

--- a/code-reviews/get-started/installation.md
+++ b/code-reviews/get-started/installation.md
@@ -53,6 +53,9 @@ Before getting started, ensure you have:
 
         ![Open and Install MCP](/images/code-reviews/get-started/installation/vscode/vscode-integration-5.webp)
 
+    !!! tip "Sign-in not working?"
+        If the browser sign-in handoff doesn't complete, [log in manually with an API key](#__tabbed_1_8) instead.
+
     **Enable**
 
     Once signed in, to enable kluster.ai in the VS Code agent chat window, take the following steps:
@@ -90,6 +93,9 @@ Before getting started, ensure you have:
         --8<-- 'text/code-reviews/code-tools.md'
 
         ![Active MCP Tools in Cursor](/images/code-reviews/get-started/installation/cursor/cursor-integration-2.webp)
+
+    !!! tip "Sign-in not working?"
+        If the browser sign-in handoff doesn't complete, [log in manually with an API key](#__tabbed_1_8) instead.
 
     **Uninstall**
 
@@ -259,6 +265,9 @@ Before getting started, ensure you have:
 
         ![Active MCP Tools in Windsurf](/images/code-reviews/get-started/installation/windsurf/windsurf-integration-7.webp)
 
+    !!! tip "Sign-in not working?"
+        If the browser sign-in handoff doesn't complete, [log in manually with an API key](#__tabbed_1_8) instead.
+
     **Uninstall**
 
     To remove kluster.ai from Windsurf, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
@@ -304,6 +313,9 @@ Before getting started, ensure you have:
 
         ![Active MCP Tools in Antigravity](/images/code-reviews/get-started/installation/antigravity/antigravity-integration-6.webp)
 
+    !!! tip "Sign-in not working?"
+        If the browser sign-in handoff doesn't complete, [log in manually with an API key](#__tabbed_1_8) instead.
+
     **Uninstall**
 
     To remove kluster.ai from Antigravity, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
@@ -344,6 +356,9 @@ Before getting started, ensure you have:
 
         ![Authorize MCP install in Kiro](/images/code-reviews/get-started/installation/kiro/kiro-integration-5.webp)
 
+    !!! tip "Sign-in not working?"
+        If the browser sign-in handoff doesn't complete, [log in manually with an API key](#__tabbed_1_8) instead.
+
     **Enable MCP**
 
     By default, Kiro disables MCP for all extensions. You must enable it before kluster can run. This is a one-time setup at the IDE level — once you click **Enable MCP**, every current and future MCP-based extension in Kiro can run, so you don't need to repeat this step for other tools.
@@ -366,6 +381,12 @@ Before getting started, ensure you have:
     **Uninstall**
 
     To remove kluster.ai from Kiro, open the Extensions panel, find **Kluster Code Reviews**, and click **Uninstall**.
+
+=== "Manual login"
+
+    Most IDEs sign you in through a browser handoff. If that flow is unavailable or fails in your editor (VS Code, Cursor, Windsurf, Antigravity, or Kiro), use the manual API-key login below.
+
+    --8<-- 'text/install-manual-login.md'
 
 ### Terminal tools
 

--- a/code-reviews/get-started/installation.md
+++ b/code-reviews/get-started/installation.md
@@ -20,7 +20,7 @@ Before getting started, ensure you have:
 
 ### IDE extensions
 
-=== "VS Code / Codex VS Code"
+=== "VS Code / Codex"
 
     **Install**
 


### PR DESCRIPTION
### Description

This pull request improves the installation and login documentation for kluster.ai IDE extensions, focusing on making manual login instructions more accessible and user-friendly. It introduces a dedicated manual login tab, adds context-sensitive tips for troubleshooting sign-in issues across multiple IDEs, and updates button links for clarity.

Documentation improvements for manual login:

* Added a dedicated "Manual login" tab in the installation guide, providing clear, step-by-step instructions for logging in with an API key if browser-based sign-in fails. [[1]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R385-R390) [[2]](diffhunk://#diff-dea68e0811a1f2cc61f0787bfe31c09ad26890aba6eaa4dbac3e640151470f9cR1-R7)
* Inserted context-specific "Sign-in not working?" tips in the installation instructions for VS Code, Cursor, Windsurf, Antigravity, and Kiro, directing users to the manual login tab when browser sign-in is unavailable. [[1]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R56-R58) [[2]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R97-R99) [[3]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R268-R270) [[4]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R316-R318) [[5]](diffhunk://#diff-ad9cbe9080e76e9312a5929b9e3caec32e0b2ab8d900e13794f52e41b9ca4e95R359-R361)

Other documentation updates:

* Updated the Antigravity install button link to use the correct protocol (`antigravity-ide:` instead of `antigravity:`) for launching the extension.
* Minor wording adjustment in the IDE extensions section header for clarity.

Goes with https://github.com/papermoonio/kluster-mkdocs/pull/181

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `kluster-mkdocs` repo
